### PR TITLE
Add deal outcome tracking to validate the deal algorithm

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 
 ## Scraper / Data
 
+- [ ] 🔴 **Find Oxylabs alternative** — Oxylabs is expensive/unreliable; evaluate alternatives (ScraperAPI, Bright Data, Zyte, etc.)
 - [ ] **Bid count filter** — deprioritise or hide items with 5+ bids (price likely already bid up)
 - [ ] **Reserve price detection** — filter out "Reserve not met" listings
 - [ ] **Seller feedback filter** — skip listings from sellers below a configurable feedback threshold
@@ -24,4 +25,4 @@
 ## Notifications & Tracking
 
 - [ ] **Ntfy / Pushover notifications** — notify once per item ID when a deal is first detected
-- [ ] **Deal outcome tracking** — record surfaced deals and what they actually sold for to validate the algorithm
+- [x] **Deal outcome tracking** — record surfaced deals and what they actually sold for to validate the algorithm

--- a/templates/Index.html
+++ b/templates/Index.html
@@ -345,6 +345,99 @@
             margin-top: 40px;
         }
 
+        /* ── Outcomes panel ──────────────────────────────────── */
+        .outcome-stats {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 24px;
+            flex-wrap: wrap;
+        }
+
+        .stat-card {
+            border: 1px solid var(--border);
+            background: var(--surface);
+            padding: 14px 20px;
+            flex: 1;
+            min-width: 100px;
+        }
+
+        .stat-label {
+            font-family: var(--sans);
+            font-size: 10px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            color: var(--muted);
+            margin-bottom: 6px;
+        }
+
+        .stat-value {
+            font-family: var(--sans);
+            font-size: 26px;
+            font-weight: 700;
+            color: var(--text);
+        }
+
+        .stat-value.green { color: var(--green); }
+        .stat-value.amber { color: var(--amber); }
+
+        .subsection-header {
+            font-family: var(--sans);
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 3px;
+            text-transform: uppercase;
+            color: var(--muted);
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin: 24px 0 12px;
+        }
+
+        .subsection-header::after {
+            content: '';
+            flex: 1;
+            height: 1px;
+            background: var(--border);
+        }
+
+        .cat-badge {
+            font-family: var(--sans);
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 1px;
+            padding: 2px 6px;
+            border-radius: 2px;
+            color: var(--muted);
+            border: 1px solid var(--border);
+        }
+
+        .outcome-win {
+            display: inline-block;
+            background: rgba(0,229,160,0.1);
+            border: 1px solid rgba(0,229,160,0.25);
+            color: var(--green);
+            font-family: var(--sans);
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 1px;
+            padding: 3px 8px;
+            border-radius: 2px;
+        }
+
+        .outcome-miss {
+            display: inline-block;
+            background: rgba(255,77,109,0.1);
+            border: 1px solid rgba(255,77,109,0.25);
+            color: var(--red);
+            font-family: var(--sans);
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 1px;
+            padding: 3px 8px;
+            border-radius: 2px;
+        }
+
         /* Scrollbar */
         ::-webkit-scrollbar { width: 6px; }
         ::-webkit-scrollbar-track { background: var(--bg); }
@@ -444,24 +537,71 @@
     <button class="tab-btn active" data-type="gpu" onclick="switchTab('gpu')">GPU<span class="tab-badge" id="badge-gpu"></span></button>
     <button class="tab-btn" data-type="cpu" onclick="switchTab('cpu')">CPU<span class="tab-badge" id="badge-cpu"></span></button>
     <button class="tab-btn" data-type="hdd" onclick="switchTab('hdd')">HDD<span class="tab-badge" id="badge-hdd"></span></button>
+    <button class="tab-btn" data-type="outcomes" onclick="switchTab('outcomes')">OUTCOMES</button>
 </div>
 
 <main>
-    <div class="section-header">
-        <span class="section-title">Active Deals</span>
-        <span class="deal-count" id="deal-count">— deals</span>
-        <button class="refresh-btn" id="refresh-btn" onclick="loadDeals()">↻ REFRESH</button>
+    <div id="panel-deals">
+        <div class="section-header">
+            <span class="section-title">Active Deals</span>
+            <span class="deal-count" id="deal-count">— deals</span>
+            <button class="refresh-btn" id="refresh-btn" onclick="loadDeals()">↻ REFRESH</button>
+        </div>
+
+        <div class="table-wrap">
+            <table>
+                <thead id="deals-head"></thead>
+                <tbody id="deals-body">
+                    <tr class="state-row">
+                        <td colspan="8"><span class="loader"></span> Loading deals...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 
-    <div class="table-wrap">
-        <table>
-            <thead id="deals-head"></thead>
-            <tbody id="deals-body">
-                <tr class="state-row">
-                    <td colspan="8"><span class="loader"></span> Loading deals...</td>
-                </tr>
-            </tbody>
-        </table>
+    <div id="panel-outcomes" style="display:none">
+        <div id="outcome-stats" class="outcome-stats"></div>
+
+        <div class="subsection-header">Resolved</div>
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Surfaced</th>
+                        <th>Cat</th>
+                        <th>Model</th>
+                        <th class="right">Surfaced @</th>
+                        <th class="right">Market Avg</th>
+                        <th class="right">Final Sale</th>
+                        <th>Outcome</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="outcomes-resolved-body">
+                    <tr class="state-row"><td colspan="8"><span class="loader"></span> Loading...</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="subsection-header" id="pending-header" style="display:none">Pending / Awaiting Result</div>
+        <div class="table-wrap" id="pending-wrap" style="display:none">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Surfaced</th>
+                        <th>Cat</th>
+                        <th>Model</th>
+                        <th class="right">Surfaced @</th>
+                        <th class="right">Market Avg</th>
+                        <th class="right">Current</th>
+                        <th>Ends</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="outcomes-pending-body"></tbody>
+            </table>
+        </div>
     </div>
 </main>
 
@@ -509,7 +649,103 @@
         document.querySelectorAll('.tab-btn').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.type === type);
         });
-        loadDeals();
+        const isOutcomes = type === 'outcomes';
+        document.getElementById('panel-deals').style.display    = isOutcomes ? 'none' : '';
+        document.getElementById('panel-outcomes').style.display = isOutcomes ? '' : 'none';
+        if (isOutcomes) {
+            loadOutcomes();
+        } else {
+            loadDeals();
+        }
+    }
+
+    function formatDate(isoStr) {
+        if (!isoStr) return '—';
+        const d = new Date(isoStr);
+        return isNaN(d) ? '—' : d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+    }
+
+    async function loadOutcomes() {
+        document.getElementById('outcomes-resolved-body').innerHTML =
+            '<tr class="state-row"><td colspan="8"><span class="loader"></span> Loading...</td></tr>';
+        try {
+            const res  = await fetch('/api/outcomes');
+            const data = await res.json();
+            if (data.status !== 'ok') throw new Error(data.message);
+            renderOutcomes(data);
+        } catch (err) {
+            document.getElementById('outcomes-resolved-body').innerHTML =
+                `<tr class="state-row"><td colspan="8">Error: ${err.message}</td></tr>`;
+        }
+    }
+
+    function renderOutcomes(data) {
+        const { summary, resolved, pending } = data;
+        const fmt = v => (v != null && !isNaN(v)) ? `£${Number(v).toFixed(2)}` : '—';
+        const total = summary.total_resolved + summary.total_pending;
+
+        document.getElementById('outcome-stats').innerHTML = `
+            <div class="stat-card"><div class="stat-label">Tracked</div><div class="stat-value">${total}</div></div>
+            <div class="stat-card"><div class="stat-label">Resolved</div><div class="stat-value">${summary.total_resolved}</div></div>
+            <div class="stat-card"><div class="stat-label">Beat Market</div><div class="stat-value green">${summary.beat_market}</div></div>
+            <div class="stat-card"><div class="stat-label">Win Rate</div><div class="stat-value ${summary.win_rate >= 50 ? 'green' : 'amber'}">${summary.win_rate}%</div></div>
+            <div class="stat-card"><div class="stat-label">Pending</div><div class="stat-value">${summary.total_pending}</div></div>
+        `;
+
+        const resolvedBody = document.getElementById('outcomes-resolved-body');
+        if (resolved.length === 0) {
+            resolvedBody.innerHTML = '<tr class="state-row"><td colspan="8">No resolved deals yet — they appear here once auctions end and the scraper picks them up as sold.</td></tr>';
+        } else {
+            resolvedBody.innerHTML = resolved.map((r, i) => {
+                const win = r.FinalPrice < r.AvgMarketPrice;
+                const pctLabel = r.ActualDiscountPct > 0
+                    ? `${r.ActualDiscountPct}% off mkt`
+                    : `${Math.abs(r.ActualDiscountPct).toFixed(1)}% over mkt`;
+                return `<tr style="animation-delay:${i * 40}ms">
+                    <td>${formatDate(r.SurfacedAt)}</td>
+                    <td><span class="cat-badge">${r.Category}</span></td>
+                    <td><div class="model-cell" style="font-size:14px">${r.Model || '—'}</div></td>
+                    <td style="text-align:right">
+                        <div class="price-current" style="font-size:13px">${fmt(r.SurfacedPrice)}</div>
+                        <div class="price-avg">${r.SurfacedDiscountPct}% off</div>
+                    </td>
+                    <td style="text-align:right"><div class="price-avg" style="font-size:13px">${fmt(r.AvgMarketPrice)}</div></td>
+                    <td style="text-align:right">
+                        <div class="${win ? 'gain' : 'price-current'}" style="font-size:13px">${fmt(r.FinalPrice)}</div>
+                        <div class="price-avg">${pctLabel}</div>
+                    </td>
+                    <td><span class="${win ? 'outcome-win' : 'outcome-miss'}">${win ? 'DEAL' : 'MISS'}</span></td>
+                    <td><a href="${safeUrl(r.URL)}" target="_blank" rel="noopener noreferrer" class="link-btn">VIEW →</a></td>
+                </tr>`;
+            }).join('');
+        }
+
+        const pendingHeader = document.getElementById('pending-header');
+        const pendingWrap   = document.getElementById('pending-wrap');
+        if (pending.length > 0) {
+            pendingHeader.style.display = '';
+            pendingWrap.style.display   = '';
+            document.getElementById('outcomes-pending-body').innerHTML = pending.map((r, i) => {
+                const ended = !r.EndTime || new Date(r.EndTime) <= Date.now();
+                return `<tr style="animation-delay:${i * 40}ms">
+                    <td>${formatDate(r.SurfacedAt)}</td>
+                    <td><span class="cat-badge">${r.Category}</span></td>
+                    <td><div class="model-cell" style="font-size:14px">${r.Model || '—'}</div></td>
+                    <td style="text-align:right">
+                        <div class="price-current" style="font-size:13px">${fmt(r.SurfacedPrice)}</div>
+                        <div class="price-avg">${r.SurfacedDiscountPct}% off</div>
+                    </td>
+                    <td style="text-align:right"><div class="price-avg" style="font-size:13px">${fmt(r.AvgMarketPrice)}</div></td>
+                    <td style="text-align:right"><div class="price-avg" style="font-size:13px">${fmt(r.CurrentPrice)}</div></td>
+                    <td><span class="time-cell ${ended ? 'urgent' : ''}" ${ended ? '' : `data-ends="${r.EndTime}"`}>${ended ? 'AWAITING' : ''}</span></td>
+                    <td><a href="${safeUrl(r.URL)}" target="_blank" rel="noopener noreferrer" class="link-btn">VIEW →</a></td>
+                </tr>`;
+            }).join('');
+            tickCountdowns();
+        } else {
+            pendingHeader.style.display = 'none';
+            pendingWrap.style.display   = 'none';
+        }
     }
 
     function formatCountdown(isoStr) {


### PR DESCRIPTION
- New DealOutcomes table (auto-created on startup) records each deal the first time it surfaces in /api/deals via INSERT IGNORE
- /api/outcomes endpoint returns resolved deals (joined to EBAY.SoldDate) with win/miss classification, plus pending items awaiting scraper pickup
- Summary stats: total tracked, resolved, beat-market count, win rate, pending
- New OUTCOMES tab in the UI with stat cards, resolved table (DEAL/MISS badges), and a pending section with live countdown timers
- e.Bids added to all three deal queries (used for BidCount at surfacing)
- TODO: added high-priority Oxylabs alternative item