### PR TITLE
Harden direct fetch session handling and Akamai resilience

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,19 @@
     "allow": [
       "Bash(git add TODO.md)",
       "Bash(git commit:*)",
-      "Bash(git push origin claude/eager-nightingale)"
+      "Bash(git push origin claude/eager-nightingale)",
+      "mcp__Claude_Preview__preview_start",
+      "Bash(git add App.py TODO.md templates/Index.html)",
+      "Bash(git push -u origin claude/brave-gould)",
+      "Bash(gh pr:*)",
+      "WebFetch(domain:scrapeops.io)",
+      "WebFetch(domain:webscrapingapi.com)",
+      "WebFetch(domain:zyte.com)",
+      "WebFetch(domain:scraperapi.com)",
+      "WebFetch(domain:www.zyte.com)",
+      "WebFetch(domain:www.scraperapi.com)",
+      "WebFetch(domain:www.webscrapingapi.com)",
+      "Bash(python -m pytest tests/ -m \"not live\" -v)"
     ]
   }
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+credentials.env
+.env
+.git/
+.gitignore
+.vscode/
+.claude/
+tests/
+pytest.ini
+README.md
+TODO.md
+__pycache__/
+*.pyc
+*.pyo

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -15,4 +15,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY App.py .
 COPY templates/ templates/
 
-CMD ["python", "App.py"]
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "-w", "2", "App:app"]

--- a/EbayScraper.py
+++ b/EbayScraper.py
@@ -109,7 +109,11 @@ def _fetch_direct(url: str) -> str | None:
         try:
             warmup = _direct_session.get(
                 'https://www.ebay.co.uk/',
-                headers={**_DIRECT_HEADERS_BASE, 'Sec-Fetch-Site': 'none'},
+                headers={
+                    **_DIRECT_HEADERS_BASE,
+                    'Sec-Fetch-Site':  'none',
+                    'Accept-Encoding': 'gzip, deflate',  # exclude br: homepage sends brotli
+                },                                       # which fails on Windows libcurl (curl 23)
                 timeout=15,
             )
             log.info(
@@ -140,7 +144,7 @@ def _fetch_direct(url: str) -> str | None:
             )
             _direct_session = None  # session may be flagged; reset for next call
             return None
-        log.debug("Fetched via curl-cffi/chrome131 (%d chars)", len(html))
+        log.info("Direct fetch OK (curl-cffi/chrome131, %d chars)", len(html))
         return html
     except Exception as e:
         log.warning("Direct fetch failed: %s", e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Web server
 flask
+gunicorn
 
 # Database
 mariadb

--- a/scheduler.py
+++ b/scheduler.py
@@ -47,6 +47,8 @@ HDD_QUERY_LIST = [
 
 def run_scraper():
     log.info("Starting scrape run...")
+    # Fresh curl-cffi session per run so Akamai cookies are re-established.
+    EbayScraper.reset_direct_session()
     common = dict(country='uk', condition='used', listing_type='auction', cache=False)
     for query_list, product_type in [
         (GPU_QUERY_LIST, 'GPU'),


### PR DESCRIPTION
Switch to persistent sessions, cookie warmup, browser bump, identity reset per run, and test isolation fixes.