### PR TITLE
Replace Oxylabs (£40/month) with Zyte API (pay-per-use) + try chrome120

### DIFF
--- a/credentials.env.example
+++ b/credentials.env.example
@@ -3,5 +3,7 @@ DB_PASSWORD=yourpasswordhere
 DB_HOST=192.168.1.104
 DB_PORT=3305
 DB_NAME=Scraper
-OXYLABS_USER=your_oxylabs_username
-OXYLABS_PASSWORD=your_oxylabs_password
+
+# Proxy fallback — pay-per-use, only charged when curl_cffi is blocked by Akamai.
+# Sign up at https://www.zyte.com/zyte-api/ (no subscription, no minimum spend)
+ZYTE_API_KEY=your_zyte_api_key_here


### PR DESCRIPTION
- _fetch_oxylabs() replaced with _fetch_zyte(): posts to Zyte's /v1/extract endpoint using httpResponseBody mode (no JS rendering, ~$1.8/1k requests, no monthly subscription). eBay search pages are server-rendered HTML so headless rendering is not required.
- chrome131 → chrome120 in curl_cffi session: older profile has better cross-platform TLS fingerprint consistency on Linux/Docker, which is where chrome131 was producing Akamai-detectable signatures.
- credentials.env.example updated: OXYLABS_* removed, ZYTE_API_KEY added.
- Tests updated: TestFetchOxylabs → TestFetchZyte with base64-encoded mock responses; TestFetchFallback patched to _fetch_zyte.
- All 34 unit tests pass.