### PR TITLE
ID-based targeted scrapes, give-up threshold & security TODO scope

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@
 - [ ] **Auto-bid button** — one-click to place a max bid on a deal listing as the auction nears its end (requires eBay OAuth integration)
 - [x] **Deal outcome tracking** — record surfaced deals and what they actually sold for to validate the algorithm
 - [x] **Outcome verification scrape** — a configurable number of hours after a tracked deal's end time, search eBay sold listings by the item title to confirm the final sale price is captured in the resolved panel (handles cases where the scheduler misses the sold listing)
-- [ ] **Fix outcome verification + give-up threshold** — `VerifyPendingOutcomes` is not resolving items as expected; investigate why (wrong search params? eBay not returning sold results for that title?); also add a configurable give-up threshold (e.g. 7 days after EndTime) after which an item is marked as permanently unresolvable rather than retried forever
+- [x] **Fix outcome verification + give-up threshold** — `VerifyPendingOutcomes` is not resolving items as expected; investigate why (wrong search params? eBay not returning sold results for that title?); also add a configurable give-up threshold (e.g. 7 days after EndTime) after which an item is marked as permanently unresolvable rather than retried forever
 
 ## Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -40,7 +40,9 @@
 
 ## Security
 
-- [ ] **Cloudflare Tunnel exposure review** — assess risks of making the Flask UI publicly accessible: add HTTP basic auth or token gate, review API endpoints for input validation, consider rate limiting
+- [ ] **HTTP Basic Auth gate** — all 5 Flask routes are unauthenticated (including `/api/deals` which writes to `DealOutcomes` on every page load); add configurable Basic Auth via `HTTP_USER` + `HTTP_PASS` env vars enforced in a `before_request` hook — no extra library needed (`App.py`)
+- [ ] **API rate limiting** — no per-IP throttling on any endpoint; add Flask-Limiter with a sensible default (e.g. 60 req/min) configurable via a `RATE_LIMIT` env var; most critical for `/api/deals` which inserts rows on each call (`App.py`, `requirements.txt`)
+- [ ] **Sanitise 500 error responses** — all five route error handlers return `str(e)` in the JSON body, which can expose internal detail (DB host, file paths); replace with a generic `"internal error"` message and log the real exception server-side (`App.py`)
 
 ## Bugs
 

--- a/credentials.env.example
+++ b/credentials.env.example
@@ -13,6 +13,9 @@ ZYTE_MAX_RETRIES=3
 # Hours after auction end before a targeted sold-listing search is run to resolve
 # any outcomes the regular scraper missed (default: 6)
 OUTCOME_VERIFY_HOURS=6
+# Days after auction end before a still-unresolved outcome is permanently
+# marked as gave-up and excluded from future verification retries (default: 7)
+OUTCOME_GIVE_UP_DAYS=7
 
 # Minutes between full query-list scrapes across all categories (default: 60)
 FULL_SCRAPE_INTERVAL_MINUTES=60

--- a/scheduler.py
+++ b/scheduler.py
@@ -24,6 +24,10 @@ log = logging.getLogger(__name__)
 # to resolve any outcomes the regular scraper missed.
 OUTCOME_VERIFY_HOURS = int(os.environ.get('OUTCOME_VERIFY_HOURS', '6'))
 
+# Days after auction end before a still-unresolved outcome is permanently
+# marked as gave-up (GaveUp=1) and excluded from future retries.
+OUTCOME_GIVE_UP_DAYS = int(os.environ.get('OUTCOME_GIVE_UP_DAYS', '7'))
+
 # Minutes between full query-list scrapes.
 FULL_SCRAPE_INTERVAL_MINUTES = int(os.environ.get('FULL_SCRAPE_INTERVAL_MINUTES', '60'))
 
@@ -96,7 +100,7 @@ def run_full_scrape():
 
     # Verify outcomes for items past their end time that are still unresolved.
     try:
-        EbayScraper.VerifyPendingOutcomes(hours_after=OUTCOME_VERIFY_HOURS)
+        EbayScraper.VerifyPendingOutcomes(hours_after=OUTCOME_VERIFY_HOURS, give_up_days=OUTCOME_GIVE_UP_DAYS)
     except Exception as e:
         log.error("Outcome verification failed: %s", e)
 

--- a/templates/Index.html
+++ b/templates/Index.html
@@ -727,6 +727,11 @@
             pendingWrap.style.display   = '';
             document.getElementById('outcomes-pending-body').innerHTML = pending.map((r, i) => {
                 const ended = !r.EndTime || new Date(r.EndTime) <= Date.now();
+                const statusCell = r.GaveUp
+                    ? `<span class="outcome-miss">UNRESOLVED</span>`
+                    : ended
+                        ? `<span class="time-cell urgent">AWAITING</span>`
+                        : `<span class="time-cell" data-ends="${r.EndTime}"></span>`;
                 return `<tr style="animation-delay:${i * 40}ms">
                     <td>${formatDate(r.SurfacedAt)}</td>
                     <td><span class="cat-badge">${r.Category}</span></td>
@@ -737,7 +742,7 @@
                     </td>
                     <td style="text-align:right"><div class="price-avg" style="font-size:13px">${fmt(r.AvgMarketPrice)}</div></td>
                     <td style="text-align:right"><div class="price-avg" style="font-size:13px">${fmt(r.CurrentPrice)}</div></td>
-                    <td><span class="time-cell ${ended ? 'urgent' : ''}" ${ended ? '' : `data-ends="${r.EndTime}"`}>${ended ? 'AWAITING' : ''}</span></td>
+                    <td>${statusCell}</td>
                     <td><a href="${safeUrl(r.URL)}" target="_blank" rel="noopener noreferrer" class="link-btn">VIEW →</a></td>
                 </tr>`;
             }).join('');


### PR DESCRIPTION
## Summary

- **Targeted scrapes: ID-based, correct sold/active split** - `ScrapeTargeted` and `VerifyPendingOutcomes` were both calling `Scrape(title[:80], ...)` which fetched both sold and active pages using an unreliable title keyword search. Replaced with a new `_scrape_item_by_id(ebay_id, category, *, sold)` helper that fetches exactly one page (sold or active) using the item ID as the eBay search term. `ScrapeTargeted` now searches active-only; `VerifyPendingOutcomes` searches sold-only. Failures log at ERROR level with full details.

- **Outcome verification give-up threshold** - Items that remain unresolved beyond `OUTCOME_GIVE_UP_DAYS` (default 7) are permanently flagged `GaveUp=1` in `DealOutcomes` and excluded from future retries. Auto-migration adds the column to existing installations on Flask startup. The OUTCOMES tab shows an UNRESOLVED badge for gave-up items instead of AWAITING.

- **Security TODO scoped** - Replaced the broad "Cloudflare Tunnel exposure review" item with 3 specific, actionable tasks: HTTP Basic Auth gate, API rate limiting, and sanitise 500 error responses.

## Test plan

- [ ] 51 unit tests pass: `python -m pytest tests/ -m "not live" -v`
- [ ] Flask startup auto-migrates `DealOutcomes` table with `GaveUp` column (`DESCRIBE Scraper.DealOutcomes`)
- [ ] Confirm `_scrape_item_by_id(..., sold=True)` URL contains `LH_Complete=1&LH_Sold=1` and not `_sop=1`
- [ ] Confirm `_scrape_item_by_id(..., sold=False)` URL contains `_sop=1` and not `LH_Sold=1`
- [ ] Set a test row EndTime to 8 days ago; run VerifyPendingOutcomes; confirm GaveUp=1 in DB and UNRESOLVED badge in OUTCOMES tab

Generated with [Claude Code](https://claude.com/claude-code)
