### PR TITLE
Fix NoneType < Decimal crash in /api/outcomes for EndedUnsold items

### DIFF
--- a/App.py
+++ b/App.py
@@ -449,7 +449,8 @@ def outcomes():
                 if row.get(col):
                     row[col] = row[col].isoformat()
 
-        beat_market = sum(1 for r in resolved if r['FinalPrice'] < r['AvgMarketPrice'])
+        beat_market = sum(1 for r in resolved if r['FinalPrice'] is not None
+                          and r['FinalPrice'] < r['AvgMarketPrice'])
         total_resolved = len(resolved)
         win_rate = round(beat_market / total_resolved * 100, 1) if total_resolved > 0 else 0
 


### PR DESCRIPTION
## Summary

- Fixes a crash in `/api/outcomes` introduced when EndedUnsold outcome
  detection was added. Items that ended without a sale have `Price = NULL`
  in the DB, so `FinalPrice` deserialises as `None` in Python. The
  `beat_market` stat was comparing `None < Decimal(...)`, raising
  `TypeError: '<' not supported between instances of 'NoneType' and 'decimal.Decimal'`
  and crashing the entire endpoint (Outcomes panel showed nothing).
- Guard added: `FinalPrice is not None` before the comparison. Semantically
  correct — EndedUnsold items never sold, so they shouldn't contribute to
  win-rate statistics.

## Test plan

- [ ] Open the app with at least one `EndedUnsold=1` row in `DealOutcomes`
- [ ] Click OUTCOMES tab → panel loads successfully (no error banner)
- [ ] Win rate % and "beat market" count reflect only actually-sold items
